### PR TITLE
Add TLS configuration instructions

### DIFF
--- a/docs/tls.md
+++ b/docs/tls.md
@@ -15,7 +15,7 @@ The configuration expects a standard Java truststore. An example of adding a CA 
 
 ```keytool -import -alias tls1 -file /etc/aerospike/ssl/tls1/cert.pem -keystore //usr/lib/jvm/java-8-openjdk-amd64/jre/lib/security/cacerts -storePass changeit
 ```
-Here are some working URL example using the above configs:
+Here are some working URL examples using the above configuration properties:
 
 ```//aerospike server detail
 //host:172.17.0.9 port:4333 namespace:test tlsname:tls1 (as per the CN, same used in the truststore alias as well)

--- a/docs/tls.md
+++ b/docs/tls.md
@@ -6,8 +6,8 @@ Below are the tls-related configs for aerospike-jdbc (example with value):
 ```tlsEnabled true
 tlsName TLS_NAME
 tlsStoreType (like jks)
-tlsTruststorePassword.   ******* (if required)
-tlsTruststorePath.  ./../XXX.jks (the full path)
+tlsTruststorePassword   ******* (if required)
+tlsTruststorePath  ./../XXX.jks (the full path)
 ```
 The full list of the valid values can be found at [AerospikeTLSPolicyConfig](https://github.com/aerospike/aerospike-jdbc/blob/main/src/main/java/com/aerospike/jdbc/tls/AerospikeTLSPolicyConfig.java).
 

--- a/docs/tls.md
+++ b/docs/tls.md
@@ -3,6 +3,7 @@
 The Aerospike JDBC driver can be configured to use SSL through the JDBC connection URL. 
 
 Below are the tls-related configs for aerospike-jdbc (example with value):
+
 ```tlsEnabled true
 tlsName TLS_NAME
 tlsStoreType (like jks)
@@ -13,8 +14,8 @@ The full list of the valid values can be found at [AerospikeTLSPolicyConfig](htt
 
 The configuration expects a standard Java truststore. An example of adding a CA certificate to the Java Truststore can be found at [Add CA certificate to Java TrustStore on client nodes](https://docs.aerospike.com/server/operations/configure/network/tls/mtls_java#add-ca-certificate-to-java-truststore-on-client-nodes).
 
-```keytool -import -alias tls1 -file /etc/aerospike/ssl/tls1/cert.pem -keystore //usr/lib/jvm/java-8-openjdk-amd64/jre/lib/security/cacerts -storePass changeit
-```
+`keytool -import -alias tls1 -file /etc/aerospike/ssl/tls1/cert.pem -keystore //usr/lib/jvm/java-8-openjdk-amd64/jre/lib/security/cacerts -storePass changeit`
+
 Here are some working URL examples using the above configuration properties:
 
 ```//aerospike server detail

--- a/docs/tls.md
+++ b/docs/tls.md
@@ -4,7 +4,8 @@ The Aerospike JDBC driver can be configured to use SSL through the JDBC connecti
 
 Below are the tls-related configs for aerospike-jdbc (example with value):
 
-```tlsEnabled true
+```
+tlsEnabled true
 tlsName TLS_NAME
 tlsStoreType (like jks)
 tlsTruststorePassword   ******* (if required)
@@ -12,14 +13,16 @@ tlsTruststorePath  ./../XXX.jks (the full path)
 ```
 The full list of the valid values can be found at [AerospikeTLSPolicyConfig](https://github.com/aerospike/aerospike-jdbc/blob/main/src/main/java/com/aerospike/jdbc/tls/AerospikeTLSPolicyConfig.java).
 
-The configuration expects a standard Java truststore. An example of adding a CA certificate to the Java Truststore can be found at [Add CA certificate to Java TrustStore on client nodes](https://docs.aerospike.com/server/operations/configure/network/tls/mtls_java#add-ca-certificate-to-java-truststore-on-client-nodes).
+The configuration expects a standard Java TrustStore. An example of adding a CA certificate to the Java TrustStore can be found at [Add CA certificate to Java TrustStore on client nodes](https://docs.aerospike.com/server/operations/configure/network/tls/mtls_java#add-ca-certificate-to-java-truststore-on-client-nodes).
 
-`keytool -import -alias tls1 -file /etc/aerospike/ssl/tls1/cert.pem -keystore //usr/lib/jvm/java-8-openjdk-amd64/jre/lib/security/cacerts -storePass changeit`
-
+```
+keytool -import -alias tls1 -file /etc/aerospike/ssl/tls1/cert.pem -keystore //usr/lib/jvm/java-8-openjdk-amd64/jre/lib/security/cacerts -storePass changeit
+```
 Here are some working URL examples using the above configuration properties:
 
-```//aerospike server detail
-//host:172.17.0.9 port:4333 namespace:test tlsname:tls1 (as per the CN, same used in the truststore alias as well)
+```
+//aerospike server detail
+//host:172.17.0.9 port:4333 namespace:test tlsname:tls1 (as per the CN, same used in the Java TrustStore alias as well)
 
 //connection URL example1
 "jdbc:aerospike:172.17.0.9:4333/test?tlsEnabled=true&tlsName=tls1&tlsTruststorePath=/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/security/cacerts&tlsTruststorePassword=changeit";

--- a/docs/tls.md
+++ b/docs/tls.md
@@ -11,7 +11,7 @@ tlsTruststorePath  ./../XXX.jks (the full path)
 ```
 The full list of the valid values can be found at [AerospikeTLSPolicyConfig](https://github.com/aerospike/aerospike-jdbc/blob/main/src/main/java/com/aerospike/jdbc/tls/AerospikeTLSPolicyConfig.java).
 
-The configuration expects a standard Java truststore. The example to add CA certificate to Java Truststore can be found at [Add CA certificate to Java TrustStore on client nodes](https://docs.aerospike.com/server/operations/configure/network/tls/mtls_java#add-ca-certificate-to-java-truststore-on-client-nodes).
+The configuration expects a standard Java truststore. An example of adding a CA certificate to the Java Truststore can be found at [Add CA certificate to Java TrustStore on client nodes](https://docs.aerospike.com/server/operations/configure/network/tls/mtls_java#add-ca-certificate-to-java-truststore-on-client-nodes).
 
 ```keytool -import -alias tls1 -file /etc/aerospike/ssl/tls1/cert.pem -keystore //usr/lib/jvm/java-8-openjdk-amd64/jre/lib/security/cacerts -storePass changeit
 ```

--- a/docs/tls.md
+++ b/docs/tls.md
@@ -1,0 +1,28 @@
+# Aerospike JDBC TLS Configuration Parameters
+
+The Aerospike JDBC driver can be configured to use SSL through the JDBC connection URL. 
+
+Below are the tls-related configs for aerospike-jdbc (example with value):
+```tlsEnabled true
+tlsName TLS_NAME
+tlsStoreType (like jks)
+tlsTruststorePassword.   ******* (if required)
+tlsTruststorePath.  ./../XXX.jks (the full path)
+```
+The full list of the valid values can be found at [AerospikeTLSPolicyConfig](https://github.com/aerospike/aerospike-jdbc/blob/main/src/main/java/com/aerospike/jdbc/tls/AerospikeTLSPolicyConfig.java).
+
+The configuration expects a standard Java truststore. The example to add CA certificate to Java Truststore can be found at [Add CA certificate to Java TrustStore on client nodes](https://docs.aerospike.com/server/operations/configure/network/tls/mtls_java#add-ca-certificate-to-java-truststore-on-client-nodes).
+
+```keytool -import -alias tls1 -file /etc/aerospike/ssl/tls1/cert.pem -keystore //usr/lib/jvm/java-8-openjdk-amd64/jre/lib/security/cacerts -storePass changeit
+```
+Here are some working URL example using the above configs:
+
+```//aerospike server detail
+//host:172.17.0.9 port:4333 namespace:test tlsname:tls1 (as per the CN, same used in the truststore alias as well)
+
+//connection URL example1
+"jdbc:aerospike:172.17.0.9:4333/test?tlsEnabled=true&tlsName=tls1&tlsTruststorePath=/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/security/cacerts&tlsTruststorePassword=changeit";
+
+//connection URL example2
+"jdbc:aerospike:172.17.0.9:4333/test?tlsEnabled=true&tlsName=tls1&tlsStoreType=jks&tlsTruststorePath=/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/security/cacerts&tlsTruststorePassword=changeit";
+```


### PR DESCRIPTION
Doc to add TLS parameters in the Aerospike JDBC URL with some tested examples