### PR TITLE
CLIENT-4802: Delegate Maven Central publish to artifact-publisher.

### DIFF
--- a/.github/docs/README.md
+++ b/.github/docs/README.md
@@ -1,58 +1,39 @@
 # GitHub Actions workflows
 
-This directory contains the CI/CD workflows and composite actions used to build, stage, and publish **aerospike-jdbc** to JFrog, Maven Central (Sonatype), and GitHub Releases.
+CI/CD for **aerospike-jdbc**: JFrog, Maven Central (via `citrusleaf/artifact-publisher`), and GitHub Releases.
 
 ## Workflows overview
 
 | Workflow | Trigger | Purpose |
 |----------|---------|---------|
-| **build** | Push/PR to `main` | Build and test on every commit. Does not publish. |
+| **build** | Push to `main`; PR to `main` or `stage` | Build and test. Does not publish. |
 | **push-to-stage** | Push to `stage`, version tags, or manual | Runs **build-release**: build, sign, deploy to JFrog, create release bundle. |
-| **build-release** | Called by `push-to-stage` only | Builds with Maven, signs artifacts, deploys to JFrog (requires shared-workflows). |
-| **promote** | Called by **promote-prod** only | Promotes a JFrog build: publish to Sonatype (staging) and create a GitHub release (draft). |
-| **promote-prod** | Manual (`workflow_dispatch`) | Promotes a specific build from stage to “prod”: run **promote** with a build number. |
-| **sonatype-approve-or-delete** | Manual (`workflow_dispatch`) | Approve or discard a Sonatype staging deployment (final step before Maven Central). |
+| **build-release** | Called by **push-to-stage** | Maven build + shared-workflows sign/deploy + release bundle. |
+| **promote** | Called by **promote-prod** only | JFrog `build-promote`, dispatch **artifact-publisher** (Maven Central), draft GitHub release. |
+| **promote-prod** | Manual (`workflow_dispatch`) | Run **promote** with **jf-build-id** from **build-release**. |
+| **sonatype-approve-or-delete** | Manual (`workflow_dispatch`) | Optional Sonatype Central Portal API (GET/POST/DELETE). **Not** used by **promote**; keep for manual ops or legacy. |
 
 ## How to run a release
 
-### 1. Build and upload to JFrog (stage)
+### 1. Build and upload to JFrog
 
-Either:
+Push to **`stage`**, push a **version tag** (`v2.0.1`, `2.0.1`, `2.0.1-rc1`, …), or run **Java Build & Release** manually. That runs **push-to-stage** → **build-release**. Maven Central / GitHub release are **not** done here.
 
-- **Push to `stage`**, or  
-- **Push a version tag** (`v2.0.1`, `2.0.1`, `v2.0.1-rc1`, etc.), or  
-- **Run “Java Build & Release”** from the Actions tab → **Run workflow**.
+### 2. Build id for promotion
 
-This runs **push-to-stage** → **build-release**: the project is built, artifacts are signed and deployed to JFrog. No Maven Central or GitHub release yet.
+From the **Build and release** job, copy workflow output **`jf-build-id`** (JFrog build id, not the GitHub run id). From JFrog UI, use the first numeric id after the build name in the build URL.
 
-### 2. Note the build number
+### 3. Promote to prod
 
-After the run finishes, get the **build number** for **Promote to Prod** in one of these ways:
+**Actions** → **Promote to Prod** → enter **`jf-build-id`** → run.
 
-- **From the workflow run:** Open the **Build and release** run and use the **jf-build-id** workflow output (a timestamp). This is not the GitHub run number.
-- **From the JFrog UI:** In a URL like `.../builds/aerospike-jdbc/1773785207202/1773785371103/published`, the build number is the **first** number after the build name: **1773785207202**. (The second number is an internal UI id; ignore it.)
+**promote** will: promote the build in JFrog to **`database-maven-dev-local`**, dispatch **`citrusleaf/artifact-publisher`** for Maven Central (see that repo’s run for progress), then create a **draft** GitHub release with artifacts.
 
-### 3. Promote to “prod” (Sonatype staging + GitHub release)
+### 4. After the run
 
-1. Go to **Actions** → **Promote to Prod**.
-2. Click **Run workflow**.
-3. Enter the **build number** from step 2.
-4. Run the workflow.
-
-This runs **promote**: it promotes that build in JFrog, uploads to Sonatype (staging), and creates a **draft** GitHub release with the artifacts. The artifact is **not** on Maven Central until you approve it in Sonatype.
-
-### 4. Approve (or discard) on Sonatype
-
-1. In Sonatype (Central Portal), find the deployment created by the promote run and copy its **stage-release-id** (UUID).
-2. Go to **Actions** → **Approve or Delete Sonatype Deployment**.
-3. Click **Run workflow**.
-4. Enter the **stage-release-id** and choose **POST** (approve) or **DELETE** (discard).
-5. Run the workflow.
-
-- **POST**: Publishes the staging deployment to Maven Central.  
-- **DELETE**: Discards the staging deployment.
-
-After **POST**, the release will sync to Maven Central. You can then publish the draft GitHub release if desired.
+- Watch **artifact-publisher** (and Maven Central sync) if needed.
+- **Publish** the draft GitHub release when ready.
+- **`main`** is **not** updated by these workflows; merge or fast-forward from **`stage`** per team process.
 
 ## Required configuration
 
@@ -60,39 +41,38 @@ After **POST**, the release will sync to Maven Central. You can then publish the
 
 | Secret | Used by | Description |
 |--------|---------|-------------|
-| `GPG_SECRET_KEY` | build-release | GPG private key (armored) for signing artifacts. |
+| `GPG_SECRET_KEY` | build-release | GPG private key (armored). |
 | `GPG_PUBLIC_KEY` | build-release | GPG public key. |
-| `GPG_PASS` | build-release | Passphrase for the GPG key. |
-| `AEROSPIKE_SA_CICD_USERNAME` | promote, sonatype-approve-or-delete | Sonatype/Central username. |
-| `AEROSPIKE_SA_CICD_PASSWORD` | promote, sonatype-approve-or-delete | Sonatype/Central token or password. |
-| `CLIENT_BOT_PAT` | promote | GitHub PAT for checkout and creating releases. |
-| `JFROG_OIDC_PROVIDER` | promote, stage-release-artifacts, publish-build-info-to-jfrog | OIDC provider name for JFrog. |
+| `GPG_PASS` | build-release | GPG passphrase. |
+| `CLIENT_BOT_PAT` | promote | PAT that can dispatch `citrusleaf/artifact-publisher`. |
+| `JFROG_OIDC_PROVIDER` | promote, stage-release-artifacts, publish-build-info-to-jfrog | OIDC provider for JFrog. |
 | `JFROG_OIDC_AUDIENCE` | promote, stage-release-artifacts, publish-build-info-to-jfrog | OIDC audience for JFrog. |
+| `AEROSPIKE_SA_CICD_USERNAME` | sonatype-approve-or-delete | Sonatype API user (manual workflow only). |
+| `AEROSPIKE_SA_CICD_PASSWORD` | sonatype-approve-or-delete | Sonatype API token/password (manual workflow only). |
 
 ### Variables (Settings → Variables)
 
 | Variable | Used by | Description |
 |----------|---------|-------------|
-| `BUILD_CONTAINER_DISTRO_VERSION` | build-release, promote | Runner image (e.g. `ubuntu-latest`). |
-| `JFROG_PROJECT` | build-release | JFrog project key. |
-| `JFROG_PLATFORM_URL` | promote | JFrog platform URL (e.g. `https://aerospike.jfrog.io`). |
-| `OIDC_PROVIDER_NAME` | build-release, promote | Same as the OIDC provider used in secrets. |
-| `OIDC_AUDIENCE` | build-release, promote | Same as the OIDC audience used in secrets. |
-| `SONATYPE_DOMAIN_NAME` | promote, sonatype-approve-or-delete | Sonatype API base (e.g. `https://central.sonatype.com`). |
-| `VALIDATION_MAX_NUMBER_CHECKS` | promote | Max polling attempts for Sonatype validation (e.g. `30`). |
+| `BUILD_CONTAINER_DISTRO_VERSION` | build-release, promote | Runner image. |
+| `JFROG_PROJECT` | build-release, promote | JFrog project key. |
+| `JFROG_PLATFORM_URL` | promote | JFrog platform URL. |
+| `OIDC_PROVIDER_NAME` | build-release, promote | OIDC provider (vars). |
+| `OIDC_AUDIENCE` | build-release, promote | OIDC audience (vars). |
+| `ARTIFACT_PUBLISHER_DISPATCH_REF` | promote | Optional ref on `artifact-publisher` (default `main`). |
+| `SONATYPE_DOMAIN_NAME` | sonatype-approve-or-delete | Sonatype API base URL. |
 
 ## Composite actions
 
-Used by the workflows above; you normally don’t run them directly.
-
-- **get-version** – Determines snapshot vs release and sets version output.
-- **stage-release-artifacts** – Downloads promoted artifacts from JFrog into staging folders for Sonatype and GitHub.
-- **publish-to-sonatype** – Uploads the staging bundle to Sonatype and waits for validation. Supports optional **dry-run** (prepare bundle and log what would be uploaded without calling Sonatype).
-- **publish-to-github** – Creates a draft GitHub release and attaches the staged artifacts.
-- **publish-build-info-to-jfrog** – Publishes build metadata (e.g. Sonatype staging id) to JFrog.
+| Action | Role |
+|--------|------|
+| **get-version** | Snapshot vs release + version outputs. |
+| **stage-release-artifacts** | Download promoted artifacts from JFrog for GitHub attach (promote passes `staging` + `github` only). |
+| **publish-to-github** | Draft GitHub release + artifacts. |
+| **publish-to-sonatype** | Not invoked by **promote**; optional for other/manual flows. |
+| **publish-build-info-to-jfrog** | Build metadata to JFrog. |
 
 ## Dependencies
 
-- **build-release** uses `aerospike/shared-workflows` (reusable workflows for build, sign, deploy to JFrog). The repo must have access to that organization and the JFrog/OIDC setup must match.
-- Version tags should match the format used in **push-to-stage** (e.g. `v2.0.1`, `2.0.1`, `v2.0.1-rc1`).
-- Workflows follow the [shared-workflows CICD standard](https://github.com/aerospike/shared-workflows/blob/main/.github/workflows/docs/CICD-standard.md). See [.github/workflows/docs/CICD-PROPOSAL.md](.github/workflows/docs/CICD-PROPOSAL.md) for alignment details and a future move to the artifacts orchestrator.
+- **build-release** uses `aerospike/shared-workflows` (reusable build/sign/deploy and release bundle).
+- Tag patterns match **push-to-stage** (`v*`, semver, `*-rc*`).

--- a/.github/docs/README.md
+++ b/.github/docs/README.md
@@ -27,7 +27,7 @@ From the **Build and release** job, copy workflow output **`jf-build-id`** (JFro
 
 **Actions** → **Promote to Prod** → enter **`jf-build-id`** → run.
 
-**promote** will: promote the build in JFrog to **`database-maven-dev-local`**, call **`citrusleaf/artifact-publisher`** as a **reusable workflow** (`publish-artifact.yaml`) for Maven Central (jobs appear in the **same** Actions run; pin `@ref` in `promote.yml` as needed), then create a **draft** GitHub release with artifacts.
+**promote** will: promote the build in JFrog to **`database-maven-dev-local`**, call **`citrusleaf/artifact-publisher`** as a **reusable workflow** (`publish-artifact.yaml` @ `ed20aecbe46a26df407033a7a9b5b94fb564abc7`) for Maven Central (jobs appear in the **same** Actions run), then create a **draft** GitHub release with artifacts.
 
 ### 4. After the run
 
@@ -72,7 +72,7 @@ From the **Build and release** job, copy workflow output **`jf-build-id`** (JFro
 
 ## Dependencies
 
-- **build-release** uses `aerospike/shared-workflows` (reusable build/sign/deploy and release bundle).
-- **promote** uses `citrusleaf/artifact-publisher` **reusable workflow** `@main` (pin a **commit SHA** in `.github/workflows/promote.yml` for reproducibility). Aerospike org settings must **allow** reusable workflows from the `citrusleaf` org if required.
+- **build-release** uses `aerospike/shared-workflows` at release tag **`v3.5.0`** (`reusable_artifacts-cicd`, `reusable_create-release-bundle`, and matching `gh-workflows-ref`).
+- **promote** uses `citrusleaf/artifact-publisher` **reusable workflow** pinned to **`ed20aecbe46a26df407033a7a9b5b94fb564abc7`**. Aerospike org settings must **allow** reusable workflows from the `citrusleaf` org if required.
 - **AWS / Maven:** jobs run in the **caller** repo context for OIDC; the trust policy for `CitrusleafArtifactPublisher` may need **`job_workflow_ref`** for `citrusleaf/artifact-publisher/.github/workflows/publish-artifact.yaml` (see GitHub docs: *Using OpenID Connect with reusable workflows*).
 - Tag patterns match **push-to-stage** (`v*`, semver, `*-rc*`).

--- a/.github/docs/README.md
+++ b/.github/docs/README.md
@@ -9,7 +9,7 @@ CI/CD for **aerospike-jdbc**: JFrog, Maven Central (via `citrusleaf/artifact-pub
 | **build** | Push to `main`; PR to `main` or `stage` | Build and test. Does not publish. |
 | **push-to-stage** | Push to `stage`, version tags, or manual | Runs **build-release**: build, sign, deploy to JFrog, create release bundle. |
 | **build-release** | Called by **push-to-stage** | Maven build + shared-workflows sign/deploy + release bundle. |
-| **promote** | Called by **promote-prod** only | JFrog `build-promote`, dispatch **artifact-publisher** (Maven Central), draft GitHub release. |
+| **promote** | Called by **promote-prod** only | JFrog `build-promote`, reusable **`citrusleaf/artifact-publisher`** workflow (Maven Central), draft GitHub release. |
 | **promote-prod** | Manual (`workflow_dispatch`) | Run **promote** with **jf-build-id** from **build-release**. |
 | **sonatype-approve-or-delete** | Manual (`workflow_dispatch`) | Optional Sonatype Central Portal API (GET/POST/DELETE). **Not** used by **promote**; keep for manual ops or legacy. |
 
@@ -27,11 +27,11 @@ From the **Build and release** job, copy workflow output **`jf-build-id`** (JFro
 
 **Actions** → **Promote to Prod** → enter **`jf-build-id`** → run.
 
-**promote** will: promote the build in JFrog to **`database-maven-dev-local`**, dispatch **`citrusleaf/artifact-publisher`** for Maven Central (see that repo’s run for progress), then create a **draft** GitHub release with artifacts.
+**promote** will: promote the build in JFrog to **`database-maven-dev-local`**, call **`citrusleaf/artifact-publisher`** as a **reusable workflow** (`publish-artifact.yaml`) for Maven Central (jobs appear in the **same** Actions run; pin `@ref` in `promote.yml` as needed), then create a **draft** GitHub release with artifacts.
 
 ### 4. After the run
 
-- Watch **artifact-publisher** (and Maven Central sync) if needed.
+- Watch the **Deploy Artifact** / Maven jobs in the run (and Maven Central sync) if needed.
 - **Publish** the draft GitHub release when ready.
 - **`main`** is **not** updated by these workflows; merge or fast-forward from **`stage`** per team process.
 
@@ -44,7 +44,6 @@ From the **Build and release** job, copy workflow output **`jf-build-id`** (JFro
 | `GPG_SECRET_KEY` | build-release | GPG private key (armored). |
 | `GPG_PUBLIC_KEY` | build-release | GPG public key. |
 | `GPG_PASS` | build-release | GPG passphrase. |
-| `CLIENT_BOT_PAT` | promote | PAT that can dispatch `citrusleaf/artifact-publisher`. |
 | `JFROG_OIDC_PROVIDER` | promote, stage-release-artifacts, publish-build-info-to-jfrog | OIDC provider for JFrog. |
 | `JFROG_OIDC_AUDIENCE` | promote, stage-release-artifacts, publish-build-info-to-jfrog | OIDC audience for JFrog. |
 | `AEROSPIKE_SA_CICD_USERNAME` | sonatype-approve-or-delete | Sonatype API user (manual workflow only). |
@@ -59,7 +58,6 @@ From the **Build and release** job, copy workflow output **`jf-build-id`** (JFro
 | `JFROG_PLATFORM_URL` | promote | JFrog platform URL. |
 | `OIDC_PROVIDER_NAME` | build-release, promote | OIDC provider (vars). |
 | `OIDC_AUDIENCE` | build-release, promote | OIDC audience (vars). |
-| `ARTIFACT_PUBLISHER_DISPATCH_REF` | promote | Optional ref on `artifact-publisher` (default `main`). |
 | `SONATYPE_DOMAIN_NAME` | sonatype-approve-or-delete | Sonatype API base URL. |
 
 ## Composite actions
@@ -75,4 +73,6 @@ From the **Build and release** job, copy workflow output **`jf-build-id`** (JFro
 ## Dependencies
 
 - **build-release** uses `aerospike/shared-workflows` (reusable build/sign/deploy and release bundle).
+- **promote** uses `citrusleaf/artifact-publisher` **reusable workflow** `@main` (pin a **commit SHA** in `.github/workflows/promote.yml` for reproducibility). Aerospike org settings must **allow** reusable workflows from the `citrusleaf` org if required.
+- **AWS / Maven:** jobs run in the **caller** repo context for OIDC; the trust policy for `CitrusleafArtifactPublisher` may need **`job_workflow_ref`** for `citrusleaf/artifact-publisher/.github/workflows/publish-artifact.yaml` (see GitHub docs: *Using OpenID Connect with reusable workflows*).
 - Tag patterns match **push-to-stage** (`v*`, semver, `*-rc*`).

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -47,9 +47,9 @@ jobs:
 
   artifacts-cicd:
     needs: extract-version
-    uses: aerospike/shared-workflows/.github/workflows/reusable_artifacts-cicd.yaml@4a5f7cd3dc79c20385a55d3c6d242e8140d98e50
+    uses: aerospike/shared-workflows/.github/workflows/reusable_artifacts-cicd.yaml@v3.5.0
     with:
-      gh-workflows-ref: 4a5f7cd3dc79c20385a55d3c6d242e8140d98e50
+      gh-workflows-ref: v3.5.0
       jf-project: ${{ vars.JFROG_PROJECT }}
       jf-build-name: aerospike-jdbc
       version: ${{ needs.extract-version.outputs.version }}
@@ -87,12 +87,12 @@ jobs:
 
   create-release-bundle:
     needs: [extract-version, artifacts-cicd]
-    uses: aerospike/shared-workflows/.github/workflows/reusable_create-release-bundle.yaml@4a5f7cd3dc79c20385a55d3c6d242e8140d98e50
+    uses: aerospike/shared-workflows/.github/workflows/reusable_create-release-bundle.yaml@v3.5.0
     with:
       jf-project: ${{ vars.JFROG_PROJECT }}
       jf-build-names: aerospike-jdbc:${{ needs.artifacts-cicd.outputs.jf-build-id }}
       jf-bundle-name: aerospike-jdbc
-      gh-workflows-ref: 4a5f7cd3dc79c20385a55d3c6d242e8140d98e50
+      gh-workflows-ref: v3.5.0
       version: ${{ needs.extract-version.outputs.version }}
       oidc-provider-name: ${{ vars.OIDC_PROVIDER_NAME }}
       oidc-audience: ${{ vars.OIDC_AUDIENCE }}

--- a/.github/workflows/promote-prod.yml
+++ b/.github/workflows/promote-prod.yml
@@ -19,5 +19,4 @@ jobs:
       build-number: ${{ inputs.build-number }}
       target-repository: database-maven-dev-local
       target-branch: main
-      source-branch: stage
     secrets: inherit

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -26,15 +26,15 @@ on:
         description: Source branch to merge from
       dry-run:
         type: boolean
-        description: If true, run publish-to-sonatype in dry-run (no upload to Sonatype)
+        description: If true, dispatch artifact-publisher with dry_run (no live Maven Central publish)
         default: false
     secrets:
       AEROSPIKE_SA_CICD_USERNAME:
-        required: true
-      AEROSPIKE_SA_CICD_PASSWORD:
-        required: true
-      CLIENT_BOT_PAT:
         required: false
+      AEROSPIKE_SA_CICD_PASSWORD:
+        required: false
+      CLIENT_BOT_PAT:
+        required: true
       JFROG_OIDC_PROVIDER:
         required: true
       JFROG_OIDC_AUDIENCE:
@@ -237,7 +237,10 @@ jobs:
           echo "${RELEASE_VERSION}"
           echo "${GIT_NOTES}"
 
-  publish-release-sonatype:
+  # Maven Central: citrusleaf/artifact-publisher (AUTOMATIC publishing). Requires CLIENT_BOT_PAT with
+  # permission to dispatch workflows on that repo. Optional repo var ARTIFACT_PUBLISHER_DISPATCH_REF
+  # (default main) selects the ref on artifact-publisher.
+  publish-maven-central:
     runs-on: ${{ vars.BUILD_CONTAINER_DISTRO_VERSION }}
     needs: promote
     steps:
@@ -246,54 +249,45 @@ jobs:
         with:
           egress-policy: audit
 
-      # Checkout required: local composite actions live in the repo (not on runner by default)
-      - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-        with:
-          ref: ${{ inputs.target-branch }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      # Pulling release from JFROG
-      - uses: ./.github/actions/stage-release-artifacts
-        with:
-          oidc-provider: ${{ secrets.JFROG_OIDC_PROVIDER }}
-          oidc-audience: ${{ secrets.JFROG_OIDC_AUDIENCE }}
-          target-repository: ${{ inputs.target-repository }}
-          build-name-number: ${{ needs.promote.outputs.build-name-number }}
-          artifact-version: ${{ needs.promote.outputs.artifact-version }}
-
-      - name: Debug staging folder contents
+      - name: Dispatch artifact-publisher (Maven Central)
+        env:
+          TOKEN: ${{ secrets.CLIENT_BOT_PAT }}
+          JFROG_PROJECT: ${{ vars.JFROG_PROJECT }}
+          REPOSITORY: ${{ format('{0}-release-bundles-v2', vars.JFROG_PROJECT) }}
+          BUNDLE_NAME: ${{ inputs.jf-target-build }}
+          BUNDLE_VERSION: ${{ needs.promote.outputs.artifact-version }}
+          DRY_RUN: ${{ inputs.dry-run && 'true' || 'false' }}
+          DISPATCH_REF: ${{ vars.ARTIFACT_PUBLISHER_DISPATCH_REF }}
+        shell: bash
         run: |
-          echo "=== staging/ ==="
-          ls -laR staging/ || echo "staging/ missing"
-          echo "=== sonatype/ ==="
-          ls -laR sonatype/ || echo "sonatype/ missing"
-
-      # Publishing release to Maven Central
-      - uses: ./.github/actions/publish-to-sonatype
-        id: publish-to-sonatype
-        with:
-          build-name-number: ${{ needs.promote.outputs.build-name-number }}
-          artifact-version: ${{ needs.promote.outputs.artifact-version }}
-          publish-user: ${{ secrets.AEROSPIKE_SA_CICD_USERNAME }}
-          publish-password: ${{ secrets.AEROSPIKE_SA_CICD_PASSWORD }}
-          validation-max-number-checks: ${{ vars.VALIDATION_MAX_NUMBER_CHECKS }}
-          sonatype-domain-name: ${{ vars.SONATYPE_DOMAIN_NAME }}
-          dry-run: ${{ inputs.dry-run }}
-      
-      # Publishing release information to JFrog for aggregation. This information is used later for final release step
-      # (acknowledgement) to Maven Central (skipped when dry-run)
-      - uses: ./.github/actions/publish-build-info-to-jfrog
-        if: inputs.dry-run != true
-        with:
-          oidc-provider: ${{ secrets.JFROG_OIDC_PROVIDER }}
-          oidc-audience: ${{ secrets.JFROG_OIDC_AUDIENCE }}
-          build-path: ${{ needs.promote.outputs.build-name-number }}
-          variables: '{"SONATYPE_STAGING_BUILD_ID":"${{ steps.publish-to-sonatype.outputs.maven-central-release-id }}"}'
+          set -euo pipefail
+          if [[ -z "${TOKEN}" ]]; then
+            echo "::error::CLIENT_BOT_PAT must be set to dispatch citrusleaf/artifact-publisher (Deploy Artifact)." >&2
+            exit 1
+          fi
+          if [[ -z "${JFROG_PROJECT}" ]]; then
+            echo "::error::JFROG_PROJECT repository variable must be set (same as build-release)." >&2
+            exit 1
+          fi
+          ref="${DISPATCH_REF:-main}"
+          body="$(jq -nc \
+            --arg ref "$ref" \
+            --arg repository "$REPOSITORY" \
+            --arg bundle_name "$BUNDLE_NAME" \
+            --arg bundle_version "$BUNDLE_VERSION" \
+            --arg dry_run "$DRY_RUN" \
+            '{ref: $ref, inputs: {repository: $repository, bundle_name: $bundle_name, bundle_version: $bundle_version, dry_run: $dry_run}}')"
+          curl -fsS -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${TOKEN}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/citrusleaf/artifact-publisher/actions/workflows/publish-artifact.yaml/dispatches" \
+            -d "$body"
+          echo "Dispatched citrusleaf/artifact-publisher@$ref (repository=$REPOSITORY bundle=$BUNDLE_NAME/$BUNDLE_VERSION dry_run=$DRY_RUN)"
 
   publish-release-github:
     runs-on: ${{ vars.BUILD_CONTAINER_DISTRO_VERSION }}
-    needs: [promote, publish-release-sonatype]
+    needs: [promote, publish-maven-central]
     if: inputs.dry-run != true
     steps:
       - name: Harden the runner (Audit all outbound calls)

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -126,11 +126,9 @@ jobs:
           echo "${RELEASE_NOTES}" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
-  # Maven Central via reusable workflow (requires workflow_call on publish-artifact.yaml in citrusleaf/artifact-publisher).
-  # Pin @ref to a commit SHA after upgrading artifact-publisher. Cross-org callers need org policy + AWS trust for job_workflow_ref.
   publish-maven-central:
     needs: promote
-    uses: citrusleaf/artifact-publisher/.github/workflows/publish-artifact.yaml@main
+    uses: citrusleaf/artifact-publisher/.github/workflows/publish-artifact.yaml@ed20aecbe46a26df407033a7a9b5b94fb564abc7
     with:
       repository: ${{ format('{0}-release-bundles-v2', vars.JFROG_PROJECT) }}
       bundle_name: ${{ inputs.jf-target-build }}

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -2,7 +2,7 @@ name: Promote
 
 permissions:
   contents: write # For creating releases
-  id-token: write # For JFrog OIDC authentication
+  id-token: write # For OIDC (reusable publish workflow + JFrog)
 
 on:
   workflow_call:
@@ -22,11 +22,9 @@ on:
         default: aerospike-jdbc
       dry-run:
         type: boolean
-        description: If true, dispatch artifact-publisher with dry_run (no live Maven Central publish)
+        description: If true, artifact-publisher dry_run (no live Maven Central publish)
         default: false
     secrets:
-      CLIENT_BOT_PAT:
-        required: true
       JFROG_OIDC_PROVIDER:
         required: true
       JFROG_OIDC_AUDIENCE:
@@ -128,52 +126,17 @@ jobs:
           echo "${RELEASE_NOTES}" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
-  # Maven Central: citrusleaf/artifact-publisher. Requires CLIENT_BOT_PAT with permission to dispatch
-  # workflows on that repo. Optional repo var ARTIFACT_PUBLISHER_DISPATCH_REF (default main).
+  # Maven Central via reusable workflow (requires workflow_call on publish-artifact.yaml in citrusleaf/artifact-publisher).
+  # Pin @ref to a commit SHA after upgrading artifact-publisher. Cross-org callers need org policy + AWS trust for job_workflow_ref.
   publish-maven-central:
-    runs-on: ${{ vars.BUILD_CONTAINER_DISTRO_VERSION }}
     needs: promote
-    steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
-        with:
-          egress-policy: audit
-
-      - name: Dispatch artifact-publisher (Maven Central)
-        env:
-          TOKEN: ${{ secrets.CLIENT_BOT_PAT }}
-          JFROG_PROJECT: ${{ vars.JFROG_PROJECT }}
-          REPOSITORY: ${{ format('{0}-release-bundles-v2', vars.JFROG_PROJECT) }}
-          BUNDLE_NAME: ${{ inputs.jf-target-build }}
-          BUNDLE_VERSION: ${{ needs.promote.outputs.artifact-version }}
-          DRY_RUN: ${{ inputs.dry-run && 'true' || 'false' }}
-          DISPATCH_REF: ${{ vars.ARTIFACT_PUBLISHER_DISPATCH_REF }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ -z "${TOKEN}" ]]; then
-            echo "::error::CLIENT_BOT_PAT must be set to dispatch citrusleaf/artifact-publisher (Deploy Artifact)." >&2
-            exit 1
-          fi
-          if [[ -z "${JFROG_PROJECT}" ]]; then
-            echo "::error::JFROG_PROJECT repository variable must be set (same as build-release)." >&2
-            exit 1
-          fi
-          ref="${DISPATCH_REF:-main}"
-          body="$(jq -nc \
-            --arg ref "$ref" \
-            --arg repository "$REPOSITORY" \
-            --arg bundle_name "$BUNDLE_NAME" \
-            --arg bundle_version "$BUNDLE_VERSION" \
-            --arg dry_run "$DRY_RUN" \
-            '{ref: $ref, inputs: {repository: $repository, bundle_name: $bundle_name, bundle_version: $bundle_version, dry_run: $dry_run}}')"
-          curl -fsS -X POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${TOKEN}" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            "https://api.github.com/repos/citrusleaf/artifact-publisher/actions/workflows/publish-artifact.yaml/dispatches" \
-            -d "$body"
-          echo "Dispatched citrusleaf/artifact-publisher@$ref (repository=$REPOSITORY bundle=$BUNDLE_NAME/$BUNDLE_VERSION dry_run=$DRY_RUN)"
+    uses: citrusleaf/artifact-publisher/.github/workflows/publish-artifact.yaml@main
+    with:
+      repository: ${{ format('{0}-release-bundles-v2', vars.JFROG_PROJECT) }}
+      bundle_name: ${{ inputs.jf-target-build }}
+      bundle_version: ${{ needs.promote.outputs.artifact-version }}
+      dry_run: ${{ inputs.dry-run && 'true' || 'false' }}
+    secrets: inherit
 
   publish-release-github:
     runs-on: ${{ vars.BUILD_CONTAINER_DISTRO_VERSION }}

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -20,19 +20,11 @@ on:
         type: string
         description: Target build name
         default: aerospike-jdbc
-      source-branch:
-        type: string
-        required: true
-        description: Source branch to merge from
       dry-run:
         type: boolean
         description: If true, dispatch artifact-publisher with dry_run (no live Maven Central publish)
         default: false
     secrets:
-      AEROSPIKE_SA_CICD_USERNAME:
-        required: false
-      AEROSPIKE_SA_CICD_PASSWORD:
-        required: false
       CLIENT_BOT_PAT:
         required: true
       JFROG_OIDC_PROVIDER:
@@ -44,7 +36,7 @@ jobs:
   promote:
     runs-on: ${{ vars.BUILD_CONTAINER_DISTRO_VERSION }}
     outputs:
-      build-name-number: ${{ steps.get-build-name-number.outputs.build-name-numbers }}
+      build-name-number: ${{ steps.get-build-meta.outputs.build-name-numbers }}
       artifact-version: ${{ steps.get-artifact-version.outputs.artifact-version }}
       release-notes: ${{ steps.get-release-notes.outputs.release-notes }}
     steps:
@@ -53,15 +45,6 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: Debug step
-        run: |
-          echo "build-number: ${{ inputs.build-number }}"
-          echo "target-repository: ${{ inputs.target-repository }}"
-          echo "target-branch: ${{ inputs.target-branch }}"
-          echo "jf-target-build: ${{ inputs.jf-target-build }}"
-          echo "source-branch: ${{ inputs.source-branch }}"
-
-      # Setting up jfrog cli
       - name: Setup jfrog shell
         uses: step-security/setup-jfrog-cli@a6b41f8338bea0983ddff6bd4ede7d2dcd81e1fa # v4.8.1
         env:
@@ -71,29 +54,22 @@ jobs:
           oidc-provider-name: ${{ vars.OIDC_PROVIDER_NAME }}
           oidc-audience: ${{ vars.OIDC_AUDIENCE }}
 
-      # Needed since we are using actions which are part of the repository
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
-          # Fetch the whole history to prevent unrelated history errors
           fetch-depth: "0"
           ref: ${{ inputs.target-branch }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      # Getting build info which will allow us to get information about the build we are promoting
-      - name: Get info
+      - name: Get build info
         id: get-build-info
         run: |
           API_PATH="/api/build/${{ inputs.jf-target-build }}/${{ inputs.build-number }}?project=database"
           status_code=$(jf rt curl "${API_PATH}" -o /dev/null -s -w "%{http_code}")
-
-          # Exit 1 unless the request succeeded (HTTP 200)
           if [[ "$status_code" -ne 200 ]]; then
             echo "ERROR: could not fetch build for build number ${{ inputs.build-number }} (HTTP $status_code)" >&2
-
             exit 1
           fi
-          
           echo build-info=$(jf rt curl "${API_PATH}" ) >> $GITHUB_OUTPUT
 
       - name: Get artifact version from JFrog build info
@@ -101,10 +77,8 @@ jobs:
         run: |
           BUILD_INFO='${{ steps.get-build-info.outputs.build-info }}'
           BUILD_NAME=$(echo "${BUILD_INFO}" | jq -r '.buildInfo.name')
-          
           ARTIFACT_BUILD_NUMBER=$(echo "${BUILD_INFO}" | jq -r '.buildInfo.modules[] | select(.id | contains("-artifacts")) | .id' | cut -d'/' -f2)
           ARTIFACT_BUILD_INFO=$(jf rt curl "/api/build/${BUILD_NAME}/${ARTIFACT_BUILD_NUMBER}?project=database" | jq -c ".")
-          
           VERSION=$(echo "${ARTIFACT_BUILD_INFO}" | jq -r '
             .buildInfo.modules[].artifacts[]
             | select(.name | endswith(".jar")
@@ -113,71 +87,39 @@ jobs:
             | .path
             | split("/")[-2]
             ' | head -n1)
-          
           if [[ -z "$VERSION" ]]; then
             echo "ERROR: Could not parse artifact version from JFrog build info!"
             exit 1
           fi
-          
-          echo "Artifact version: ${VERSION}"
           echo "artifact-version=${VERSION}" >> $GITHUB_OUTPUT
 
-      # Snapshot builds are not promoted to production
-      - name: Check if snapshot build
-        id: check-snapshot
+      - name: Reject SNAPSHOT builds
         run: |
           VERSION="${{ steps.get-artifact-version.outputs.artifact-version }}"
-          
-          echo "Parsed version: $VERSION"
-          
           if [[ "$VERSION" == *"-SNAPSHOT" ]]; then
             echo "Error: Build ${{ inputs.jf-target-build }} with build number ${{ inputs.build-number }} is a SNAPSHOT build. Snapshots are not promoted to production."
             exit 1
           fi
 
-      # Fetching commit hash from the build info. The commit hash is used for SNAPSHOT builds
-      - name: Get commit hash from repo
-        id: get-commit-hash
+      - name: Resolve JFrog build name
+        id: get-build-meta
         run: |
-          BUILD_INFO='${{ steps.get-build-info.outputs.build-info }}'
-
-          # Try to get from vcs first
-          COMMIT_HASH=$(echo "$BUILD_INFO" | jq -r '.buildInfo.vcs[0].revision // empty')
-
-          if [ -z "$COMMIT_HASH" ] || [ "$COMMIT_HASH" == "null" ]; then
-            # Fallback: extract from module ID
-            COMMIT_HASH=$(echo "$BUILD_INFO" | jq -r '.buildInfo.modules[0].id' | sed -E 's/.*SNAPSHOT_(.*)$/\1/')
-          fi
-          echo "commit-hash=$COMMIT_HASH" >> $GITHUB_OUTPUT
-
-      # Fetching build name for build promotion process. The build name will contain build numbers.
-      # This command parses json and pulls out the build name
-      - name: Get build name
-        id: get-build-name
-        run: |
-          echo build-names=$(echo '${{ steps.get-build-info.outputs.build-info }}' | jq -r '.buildInfo.name') >> $GITHUB_OUTPUT
-
-      - name: Debug
-        run: |
-          echo "commit-hash: '${{ steps.get-commit-hash.outputs.commit-hash }}'"
-          echo "build-name: '${{ steps.get-build-name.outputs.build-names }}'"
-
-      # Promoting build to production
-      - name: Promote build
-        shell: bash
-        run: |
-          BUILD_NAME="${{ steps.get-build-name.outputs.build-names }}"
-          BUILD_NUMBER="${{ inputs.build-number }}"
-    
+          BUILD_NAME=$(echo '${{ steps.get-build-info.outputs.build-info }}' | jq -r '.buildInfo.name')
           if [ -z "$BUILD_NAME" ]; then
             echo "Error: Missing build name"
             exit 1
           fi
-    
-          echo "Promoting build '$BUILD_NAME' (build #$BUILD_NUMBER) to ${{ inputs.target-repository }}"
+          echo "build-names=${BUILD_NAME}" >> $GITHUB_OUTPUT
+          echo "build-name-numbers=${BUILD_NAME}/${{ inputs.build-number }}" >> $GITHUB_OUTPUT
+
+      - name: Promote build in JFrog
+        shell: bash
+        run: |
+          BUILD_NAME="${{ steps.get-build-meta.outputs.build-names }}"
+          BUILD_NUMBER="${{ inputs.build-number }}"
+          echo "Promoting build '${BUILD_NAME}' (#${BUILD_NUMBER}) to ${{ inputs.target-repository }}"
           jf rt build-promote --copy=true "$BUILD_NAME" "$BUILD_NUMBER" "${{ inputs.target-repository }}"
 
-      # Fetching release notes from commit logs
       - name: Generate release notes
         id: get-release-notes
         run: |
@@ -186,60 +128,8 @@ jobs:
           echo "${RELEASE_NOTES}" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
-      - name: Debug print release notes
-        run: |
-          echo "Changes for release ${{ steps.get-artifact-version.outputs.artifact-version }}"
-          echo "${{ steps.get-release-notes.outputs.release-notes }}"
-      
-      # Fast forward the target branch to the source branch.
-#      - name: Fast forward
-#        shell: bash
-#        run: |
-#          # Making sure we have latest history in place to be able to fast forward merge
-#          git status
-#          git checkout ${{ inputs.source-branch }}
-#          git checkout ${{ inputs.target-branch }}
-#          git merge --ff-only ${{ inputs.source-branch }}
-#
-#      # Adding commit message for promotion
-#      - name: Add tagging message
-#        uses: stefanzweifel/git-auto-commit-action@v4
-#        with:
-#          commit_message: "Promote to prod [skip ci]"
-#          commit_author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
-#          tagging_message: Promote to PROD
-#          branch: ${{ inputs.target-branch }}
-
-      # Pushing changes to remote head branch
-      # This needs updating to create PR instead of direct push
-#      - name: Upload changes to remote head branch
-#        shell: bash
-#        run: git push
-
-      # Passing build-name-numbers and artifact-version to the next job
-      - name: Get build name with build number
-        id: get-build-name-number
-        run: |
-          echo "DEBUG: inputs.build-number='${{ inputs.build-number }}'"
-          BUILD_NAME=$(echo '${{ steps.get-build-info.outputs.build-info }}' | jq -r '.buildInfo.name')
-          BUILD_NUMBER="${{ inputs.build-number }}"
-          echo "build-name-numbers=${BUILD_NAME}/${BUILD_NUMBER}" >> $GITHUB_OUTPUT
-
-      - name: Debug show 'build-name-numbers' and 'artifact-version'
-        run: |
-          echo "build-name-number: ${{ steps.get-build-name-number.outputs.build-name-numbers }}"
-          echo "artifact-version: ${{ steps.get-artifact-version.outputs.artifact-version }}"
-
-      - name: Release debug
-        run: |
-          GIT_NOTES='${{ steps.get-release-notes.outputs.release-notes }}'
-          RELEASE_VERSION='${{steps.get-artifact-version.outputs.artifact-version }}'
-          echo "${RELEASE_VERSION}"
-          echo "${GIT_NOTES}"
-
-  # Maven Central: citrusleaf/artifact-publisher (AUTOMATIC publishing). Requires CLIENT_BOT_PAT with
-  # permission to dispatch workflows on that repo. Optional repo var ARTIFACT_PUBLISHER_DISPATCH_REF
-  # (default main) selects the ref on artifact-publisher.
+  # Maven Central: citrusleaf/artifact-publisher. Requires CLIENT_BOT_PAT with permission to dispatch
+  # workflows on that repo. Optional repo var ARTIFACT_PUBLISHER_DISPATCH_REF (default main).
   publish-maven-central:
     runs-on: ${{ vars.BUILD_CONTAINER_DISTRO_VERSION }}
     needs: promote
@@ -310,8 +200,6 @@ jobs:
           artifact-version: ${{ needs.promote.outputs.artifact-version }}
           staging-folder: '["staging","github"]'
 
-      # Publishing release to GitHub
-      # Note: this action knows how to process json internally. It expects inputs to be in json format
       - uses: ./.github/actions/publish-to-github
         with:
           release-notes: ${{ needs.promote.outputs.release-notes }}


### PR DESCRIPTION
Replace in-repo Sonatype composite steps with a GitHub API dispatch of citrusleaf/artifact-publisher Deploy Artifact, using the prod release bundle (JFROG_PROJECT-release-bundles-v2) and AUTOMATIC Central publishing.

- publish-release-github now depends on publish-maven-central.

- Require CLIENT_BOT_PAT for dispatch; Sonatype SA secrets optional on this path.

- Optional ARTIFACT_PUBLISHER_DISPATCH_REF repo variable overrides dispatch ref (default main).